### PR TITLE
suffix, separatorが連続することがあって気になる

### DIFF
--- a/git-prompt.zsh
+++ b/git-prompt.zsh
@@ -193,7 +193,9 @@ function _zsh_git_prompt_git_status() {
                     } else if (UPSTREAM_TYPE == "full") {
                         print UPSTREAM_PREFIX;
                         print upstream;
-                        print UPSTREAM_SUFFIX;
+                        if (behind < 0 || ahead > 0) {
+                            print UPSTREAM_SUFFIX;
+                        }
                     }
                 }
                 print RC;
@@ -210,7 +212,9 @@ function _zsh_git_prompt_git_status() {
                     print RC;
                 }
 
-                print SEPARATOR;
+                if (unmerged > 0 || staged > 0 || unstaged > 0 || untracked > 0) {
+                    print SEPARATOR;
+                }
 
                 if (unmerged > 0) {
                     print UNMERGED;


### PR DESCRIPTION
suffix, separatorをspaceにしていると空白が連続する事があって気になる。  
```diff
user@host:~ (master→ github/master  *)
user@host:~ (master→ github/master *)
```

自分の使い方だとarrayをjoinして出力みたいなのでも良いくらい。  
